### PR TITLE
Remove `xdg` dependency.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -76,7 +76,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.7.0"
+version = "3.7.2"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -296,24 +296,16 @@ argparse = "*"
 ordereddict = "*"
 
 [[package]]
-name = "xdg"
-version = "5.0.1"
-description = "Variables defined by the XDG Base Directory Specification"
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[[package]]
 name = "zipp"
-version = "3.4.0"
+version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 github_actions = []
@@ -321,7 +313,7 @@ github_actions = []
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<4.0"
-content-hash = "a0541ddae9aa66c9b533a8e975b85b10da04a32f16d74b05d3495d46d2bd04de"
+content-hash = "624e3e779aab767377416920bc0f47b369944fbc3ed36f170ea46c585e912c75"
 
 [metadata.files]
 argparse = [
@@ -357,8 +349,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.7.0-py3-none-any.whl", hash = "sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614"},
-    {file = "importlib_metadata-3.7.0.tar.gz", hash = "sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa"},
+    {file = "importlib_metadata-3.7.2-py3-none-any.whl", hash = "sha256:407d13f55dc6f2a844e62325d18ad7019a436c4bfcaee34cda35f2be6e7c3e34"},
+    {file = "importlib_metadata-3.7.2.tar.gz", hash = "sha256:18d5ff601069f98d5d605b6a4b50c18a34811d655c55548adc833e687289acde"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -483,11 +475,7 @@ urllib3 = [
 versio = [
     {file = "Versio-0.4.0.tar.gz", hash = "sha256:7a7346d81ad0a0186bfc846736296a3381b728d322c1e47763c111608e9426d4"},
 ]
-xdg = [
-    {file = "xdg-5.0.1-py3-none-any.whl", hash = "sha256:9ddd6649bee9148f952305603a08474e3ef37c909eb19dfcb9737d54ebcc407e"},
-    {file = "xdg-5.0.1.tar.gz", hash = "sha256:97a27058caa61b4ce04e05471643caa6bc8c563d2638f92c0516ac50208146d8"},
-]
 zipp = [
-    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
-    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
+    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
+    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dirty = true
 python = ">=3.6,<4.0"
 versio = { version="*" }
 importlib-metadata = { version="*" }
-xdg = { version="*" }
 requests = { version="*" }
 
 [tool.poetry.dev-dependencies]

--- a/slacktoken/token.py
+++ b/slacktoken/token.py
@@ -1,18 +1,23 @@
 import json
+import os
 import pathlib
 import re
 import sqlite3
 import typing
 
 import requests
-import xdg
 
 import slacktoken.exceptions
 
 _API_TOKEN_MATCHER = re.compile("\"api_token\":\"([^\"]+)\"")
+_XDG_CONFIG_DIR_VARIABLE = "XDG_CONFIG_DIR"
 
 def _get_slack_configuration_directory() -> pathlib.Path:
-	return xdg.xdg_config_home() / "Slack"
+	if _XDG_CONFIG_DIR_VARIABLE in os.environ:
+		config_directory = pathlib.Path(_XDG_CONFIG_DIR_VARIABLE)
+	else:
+		config_directory = pathlib.Path.home() / ".config"
+	return config_directory / "Slack"
 
 def _get_slack_cookies() -> typing.Dict[str, str]:
 	cookie_database_path = _get_slack_configuration_directory() / "Cookies"


### PR DESCRIPTION
The real `xdg` package on PyPi appears to conflict with another package also called `xdg` that ends up pre-installed on a lot of Ubuntu machines.

I think it's therefore easiest if we just remove this dependency.