### PR TITLE
Return authentication cookies along with the token.

### DIFF
--- a/slacktoken/commands/get.py
+++ b/slacktoken/commands/get.py
@@ -1,6 +1,9 @@
 import argparse
+import urllib.parse
 
 import slacktoken.token
 
 def command(arguments:argparse.Namespace) -> None:
-	print(slacktoken.token.get(arguments.workspace))
+	authentication_information = slacktoken.token.get(arguments.workspace)
+	print(authentication_information.token)
+	print("; ".join([f"{urllib.parse.quote(key)}={urllib.parse.quote(value)}" for key, value in authentication_information.cookies.items()]))

--- a/slacktoken/token.py
+++ b/slacktoken/token.py
@@ -12,6 +12,11 @@ import slacktoken.exceptions
 _API_TOKEN_MATCHER = re.compile("\"api_token\":\"([^\"]+)\"")
 _XDG_CONFIG_DIR_VARIABLE = "XDG_CONFIG_DIR"
 
+class SlackAuthenticationInformation():
+	def __init__(self, token:str, cookies:typing.Dict[str, str]):
+		self.token = token
+		self.cookies = cookies
+
 def _get_slack_configuration_directory() -> pathlib.Path:
 	if _XDG_CONFIG_DIR_VARIABLE in os.environ:
 		config_directory = pathlib.Path(_XDG_CONFIG_DIR_VARIABLE)
@@ -39,7 +44,7 @@ def _get_slack_workspaces() -> typing.List[str]:
 		workspaces = json.load(workspaces_file)
 	return [workspace["domain"] for workspace in workspaces.values()]
 
-def get(workspace:typing.Optional[str]) -> str:
+def get(workspace:typing.Optional[str]) -> SlackAuthenticationInformation:
 	cookies = _get_slack_cookies()
 	workspaces = _get_slack_workspaces()
 	if not workspaces:
@@ -56,4 +61,4 @@ def get(workspace:typing.Optional[str]) -> str:
 	matcher = _API_TOKEN_MATCHER.search(response.text)
 	if matcher is None:
 		raise slacktoken.exceptions.InternalException("Could not extract Slack token from webpage. Maybe the Slack webpage has changed.")
-	return matcher.group(1)
+	return SlackAuthenticationInformation(matcher.group(1), cookies)


### PR DESCRIPTION
It seems like Slack now actually requires that you send authentication cookies to the API when you're using a token. This updates the library and command line to return these cookies.

Cookies are returned as a key-value dictionary from the library, and printed as a `Cookie` compatible header on the command line.

This is unfortunately a breaking change, but since using a token alone is already broken that seems like a minor detail.