### PR TITLE
Remove the concurrency limit.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,6 @@ on:
         description: "Enable remote debugging for a specific job."
         required: false
 
-concurrency: integration
-
 jobs:
   check-permissions:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id }}


### PR DESCRIPTION
This doesn't really work very well, because there's no option to not cancel pending runs when the concurrency limit is reached.